### PR TITLE
Reduce tightness of mideleg register assertion (required for H-extension)

### DIFF
--- a/machine/minit.c
+++ b/machine/minit.c
@@ -82,7 +82,7 @@ static void delegate_traps()
 
   write_csr(mideleg, interrupts);
   write_csr(medeleg, exceptions);
-  assert(read_csr(mideleg) == interrupts);
+  assert((read_csr(mideleg) & interrupts) == interrupts);
   assert(read_csr(medeleg) == exceptions);
 }
 


### PR DESCRIPTION
The write-and-then read assertion in `minit.c` of the full `mideleg` register i.e.

```
write_csr(mideleg, interrupts);
assert((read_csr(mideleg) & interrupts) == interrupts);
```
is too tight with the new (frozen) hypervisor privilege spec, which contains read-only bits

```
8.4.2 Machine Interrupt Delegation Register (mideleg)
When the hypervisor extension is implemented, bits 10, 6, and 2 of mideleg (corresponding to the
standard VS-level interrupts) are each read-only one. Furthermore, if any guest external interrupts
are implemented (GEILEN is nonzero), bit 12 of mideleg (corresponding to supervisor-level guest
external interrupts) is also read-only one. VS-level interrupts and guest external interrupts are
always delegated past M-mode to HS-mode.
For bits of mideleg that are zero, the corresponding bits in hideleg, hip, and hie are read-only
zeros.
```
cited from the `The RISC-V Instruction Set Manual, Volume II: Privileged Architecture, Document Version 20211105-signoff`