### PR TITLE
No explicit -lgcc

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -96,7 +96,7 @@ LDFLAGS="$LDFLAGS -Wl,--build-id=none"
 
 AC_SUBST(CFLAGS)
 AC_SUBST(LDFLAGS)
-AC_SUBST([LIBS], ["-lgcc"])
+AC_SUBST(LIBS)
 AC_SUBST(WITH_ARCH)
 AC_SUBST(host_alias)
 

--- a/configure.ac
+++ b/configure.ac
@@ -96,7 +96,7 @@ LDFLAGS="$LDFLAGS -Wl,--build-id=none"
 
 AC_SUBST(CFLAGS)
 AC_SUBST(LDFLAGS)
-AC_SUBST(LIBS)
+AC_CHECK_LIB([gcc], [__ashlsi3], AC_SUBST([LIBS], ["-lgcc"]), AC_SUBST([LIBS]))
 AC_SUBST(WITH_ARCH)
 AC_SUBST(host_alias)
 


### PR DESCRIPTION
For Clang/LLVM user with NO cross gcc installed,
there is no libgcc available; At this time user
can manually export LIBS=-lclang-rt.

For cross gcc user, -lgcc is usually added by the
compiler thus there is no need to add this flag
in config file.
Only when -nostdlib/-nodefaultlibs is specified
should we add -lgcc, which is not the case here.

This compiles on a machine with cross gcc installed and another machine with only clang. However, only rv64 is tested.

Note: ./configure not re-generated w.r.t #263