### PR TITLE
Eliminate Wunknown-pragmas for Clang/LLVM

### DIFF
--- a/util/string.c
+++ b/util/string.c
@@ -4,7 +4,7 @@
 #include <stdint.h>
 #include <ctype.h>
 
-#ifdef __GNUC__
+#if defined(__GNUC__) && !defined(__llvm__)
 // Don't let GCC pattern-match these functions' bodies into self-calls
 #pragma GCC optimize ("no-tree-loop-distribute-patterns")
 #endif


### PR DESCRIPTION
With Clang/LLVM,
```
/home/zenithal/T/playground/dependencies/riscv-pk/util/string.c:9:13: error: unknown pragma ignored [-Werror,-Wunknown-pragmas]
#pragma GCC optimize ("no-tree-loop-distribute-patterns")
            ^
1 error generated.
```