### PR TITLE
Eliminate Wuninitialized for Clang/LLVM

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -91,7 +91,7 @@ AS_IF([test "x$enable_print_device_tree" = "xyes"], [
   AC_DEFINE([PK_PRINT_DEVICE_TREE],,[Define if the DTS is to be displayed])
 ])
 
-CFLAGS="-Wall -Werror -D__NO_INLINE__ -mcmodel=medany -O2 -std=gnu99 -Wno-unused -Wno-attributes -fno-delete-null-pointer-checks -fno-PIE"
+CFLAGS="-Wall -Werror -D__NO_INLINE__ -mcmodel=medany -O2 -std=gnu99 -Wno-unused -Wno-attributes -Wno-uninitialized -fno-delete-null-pointer-checks -fno-PIE"
 LDFLAGS="$LDFLAGS -Wl,--build-id=none"
 
 AC_SUBST(CFLAGS)


### PR DESCRIPTION
```
/home/zenithal/T/playground/dependencies/riscv-pk/pk/console.c:68:43: error: variable 'ra' is uninitialized when used here [-Werror,-Wuninitialized]
  do_panic("assertion failed @ %p: %s\n", ra, s);
                                          ^~
/home/zenithal/T/playground/dependencies/riscv-pk/pk/console.c:67:24: note: initialize the variable 'ra' to silence this warning
  register uintptr_t ra asm ("ra");
                       ^
                        = 0
1 error generated.
```

Though this seems to be the fault of Clang.