### PR TITLE
Fix local variable register usage for ra

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -91,7 +91,7 @@ AS_IF([test "x$enable_print_device_tree" = "xyes"], [
   AC_DEFINE([PK_PRINT_DEVICE_TREE],,[Define if the DTS is to be displayed])
 ])
 
-CFLAGS="-Wall -Werror -D__NO_INLINE__ -mcmodel=medany -O2 -std=gnu99 -Wno-unused -Wno-attributes -Wno-uninitialized -fno-delete-null-pointer-checks -fno-PIE"
+CFLAGS="-Wall -Werror -D__NO_INLINE__ -mcmodel=medany -O2 -std=gnu99 -Wno-unused -Wno-attributes -fno-delete-null-pointer-checks -fno-PIE"
 LDFLAGS="$LDFLAGS -Wl,--build-id=none"
 
 AC_SUBST(CFLAGS)

--- a/pk/console.c
+++ b/pk/console.c
@@ -64,6 +64,5 @@ void do_panic(const char* s, ...)
 
 void kassert_fail(const char* s)
 {
-  register uintptr_t ra asm ("ra");
-  do_panic("assertion failed @ %p: %s\n", ra, s);
+  do_panic("assertion failed @ %p: %s\n", __builtin_return_address(0), s);
 }


### PR DESCRIPTION
See https://gcc.gnu.org/onlinedocs/gcc/Local-Register-Variables.html#Local-Register-Variables
"Other than when invoking the Extended asm, the contents of the
specified register are not guaranteed."

Also revert 90191ad93eac47d61ab9cc89084050ad1541d160.