### PR TITLE
Fix a file leak in function `at_kfd`

### DIFF
--- a/pk/syscall.c
+++ b/pk/syscall.c
@@ -129,7 +129,9 @@ static int at_kfd(int dirfd)
   file_t* dir = file_get(dirfd);
   if (dir == NULL)
     return -1;
-  return dir->kfd;
+  int kfd = dir->kfd;
+  file_decref(dir);
+  return kfd;
 }
 
 int sys_openat(int dirfd, const char* name, int flags, int mode)


### PR DESCRIPTION
The following program (`test.c`) should never exit:

```c
#include <unistd.h>
#include <fcntl.h>
#include <errno.h>
#include <stdio.h>
#include <assert.h>

int main() {
  int iters = 0;
  for (;;) {
    int dirfd = open(".", O_DIRECTORY);
    assert(dirfd > 0);
    int fd = openat(dirfd, "test.c", O_RDONLY);
    if (fd < 0) {
      break;
    } else {
      close(fd);
      close(dirfd);
    }
    ++iters;
  }
  printf("iters = %d, errno = %d\n", iters, errno);
  return 0;
}
```

but it fails and the output is `iters = 123, errno = 12`, because the function `at_kfd` (in `syscall.c`) calls `file_get`, but does not call `file_decref` before returning.