### PR TITLE
pk: allow mprotect to change existing mappings protections

### DIFF
--- a/pk/mmap.c
+++ b/pk/mmap.c
@@ -484,21 +484,8 @@ uintptr_t do_mprotect(uintptr_t addr, size_t length, int prot)
   
       if (!(*pte & PTE_V)) {
         vmr_t* v = (vmr_t*)*pte;
-        if((v->prot ^ prot) & ~v->prot){
-          //TODO:look at file to find perms
-          res = -EACCES;
-          break;
-        }
         v->prot = prot;
       } else {
-        if (!(*pte & PTE_U) ||
-            ((prot & PROT_READ) && !(*pte & PTE_R)) ||
-            ((prot & PROT_WRITE) && !(*pte & PTE_W)) ||
-            ((prot & PROT_EXEC) && !(*pte & PTE_X))) {
-          //TODO:look at file to find perms
-          res = -EACCES;
-          break;
-        }
         *pte = pte_create(pte_ppn(*pte), prot_to_type(prot, 1));
       }
 


### PR DESCRIPTION
The man page for mprotect states in the notes section:
      "On Linux, it is always permissible to call mprotect() on any
       address in a process's address space (except for the kernel
       vsyscall area).  In particular, it can be used to change existing
       code mappings to be writable."

Currently, if the page table entry is valid and the new prot is
more permissive in any way when compared to the prior one, mprotect
fails.

IIUC, This prevents changing an existing mapping to be writeable.

This commit removes that check.