### PR TITLE
Fix syscall gettimeofday in 32-bit emulator

### DIFF
--- a/pk/syscall.c
+++ b/pk/syscall.c
@@ -518,6 +518,12 @@ int sys_times(long* loc)
 
 int sys_gettimeofday(long* loc)
 {
+#if __riscv_xlen == 32
+  char kbuf[MAX_BUF];
+  uint64_t ret = frontend_syscall(SYS_gettimeofday, kva2pa(kbuf), 0, 0, 0, 0, 0, 0);
+  memcpy_to_user(loc, kbuf, sizeof(long));
+  memcpy_to_user((char *)loc + 8, kbuf + 8, sizeof(long));
+#else
   uint64_t t = rdcycle64();
 
   long kloc[2];
@@ -525,7 +531,7 @@ int sys_gettimeofday(long* loc)
   kloc[1] = (t % CLOCK_FREQ) / (CLOCK_FREQ / 1000000);
 
   memcpy_to_user(loc, kloc, sizeof(kloc));
-  
+#endif
   return 0;
 }
 


### PR DESCRIPTION
When running the 32-bit emulator, we've discovered that the proxy kernel generates inaccurate time results when the 'gettimeofday' system call is made. However, the 64-bit emulator doesn't seem to be impacted by this issue. To address this problem, we've made a modification to the system by forwarding the 'gettimeofday' system call to the Spike front-end server. This allows us to receive the correct time results and resolve the problem. The modification includes both the proxy kernel and Spike.

## Issue reproduction
* [dhrystone source code](https://github.com/qwe661234/rv32emu/blob/master/tests/dhrystone.c)
### 1. Compile
```
riscv32-unknown-elf-gcc -march=rv32g -O2 ./dhrystone.c -o dhrystone.elf
```
### 2. Execute
```
/path/to/spike --isa=rv32g /path/to/32-bit_proxy_kernel dhrystone.elf
```
Related: https://github.com/riscv-software-src/riscv-isa-sim/pull/1318