### PR TITLE
pk: fix __do_brk when new addr is not feasible

### DIFF
--- a/pk/elf.c
+++ b/pk/elf.c
@@ -96,6 +96,7 @@ void load_elf(const char* fn, elf_info* info)
   }
 
   file_decref(file);
+  info->brk = ROUNDUP(info->brk_min, RISCV_PGSIZE);
   return;
 
 fail:

--- a/pk/mmap.c
+++ b/pk/mmap.c
@@ -433,13 +433,8 @@ uintptr_t do_mmap(uintptr_t addr, size_t length, int prot, int flags, int fd, of
 uintptr_t __do_brk(size_t addr)
 {
   uintptr_t newbrk = addr;
-  if (addr < current.brk_min)
-    newbrk = current.brk_min;
-  else if (addr > current.brk_max)
-    newbrk = current.brk_max;
-
-  if (current.brk == 0)
-    current.brk = ROUNDUP(current.brk_min, RISCV_PGSIZE);
+  if (addr < current.brk_min || addr > current.brk_max)
+    return current.brk;
 
   uintptr_t newbrk_page = ROUNDUP(newbrk, RISCV_PGSIZE);
   if (current.brk > newbrk_page) {


### PR DESCRIPTION
Linux kernel simply returns current brk when request brk addr is not feasible. The pk should probably do the same.

Programs like `sbrk` in glibc expect `syscall(SYS_brk, NULL)` to return the current brk value. Mysterious bugs occur if pk `munmap`s all allocated brk memory and return `brk_min`.