### PR TITLE
Add ENOSYS stub for syscall 278, getrandom

### DIFF
--- a/pk/syscall.c
+++ b/pk/syscall.c
@@ -632,6 +632,7 @@ long do_syscall(long a0, long a1, long a2, long a3, long a4, long a5, unsigned l
     [SYS_rt_sigprocmask] = sys_stub_success,
     [SYS_clock_gettime] = sys_clock_gettime,
     [SYS_chdir] = sys_chdir,
+    [SYS_getrandom] = sys_stub_nosys,
   };
 
   const static void* old_syscall_table[] = {

--- a/pk/syscall.h
+++ b/pk/syscall.h
@@ -57,6 +57,7 @@
 #define SYS_set_tid_address 96
 #define SYS_set_robust_list 99
 #define SYS_madvise 233
+#define SYS_getrandom 278
 #define SYS_statx 291
 
 #define OLD_SYSCALL_THRESHOLD 1024


### PR DESCRIPTION
Binaries built with a recent LLVM and current riscv-gnu-toolchain and targeting riscv64-unknown-linux-gnu fail to execute under Spike+pk with this output:
```
$ /scratch/projects/riscv-isa-sim//build/spike \
    --varch=vlen:128,elen:64 --isa=rv64gcv_zvkned \
    /rivos/riscv-pk/riscv64-unknown-linux-gnu/bin/pk aes-cbc-test
bbl loader
bad syscall #278!
```

Syscall 278 is getrandom which is invoked prior to reaching main(). Providing a syscall stub to return ENOSYS is enough to please the caller. This has the additional benefit of not requiring to implement getrandom() in a portable way.

```
$ /scratch/projects/riscv-isa-sim//build/spike \
    --varch=vlen:128,elen:64 --isa=rv64gcv_zvkned \
    /rivos/riscv-pk/riscv64-unknown-linux-gnu/bin/pk aes-cbc-test
bbl loader
vlen: 128 bits
--- Running 'CBCKeySbox256' test suite...
...
```