### PR TITLE
Add support for "riscv-none-*" host name

### DIFF
--- a/scripts/config.sub
+++ b/scripts/config.sub
@@ -300,7 +300,7 @@ case $basic_machine in
 	| powerpc | powerpc64 | powerpc64le | powerpcle \
 	| pru \
 	| pyramid \
-	| riscv32 | riscv64 \
+	| riscv | riscv32 | riscv64 \
 	| rl78 | rx \
 	| score \
 	| sh | sh[1234] | sh[24]a | sh[24]aeb | sh[23]e | sh[234]eb | sheb | shbe | shle | sh[1234]le | sh3ele \
@@ -1312,6 +1312,9 @@ case $basic_machine in
 		basic_machine=powerpc-apple
 		;;
 	*-unknown)
+		# Make sure to match an already-canonicalized machine name.
+		;;
+	*-none)
 		# Make sure to match an already-canonicalized machine name.
 		;;
 	*)


### PR DESCRIPTION
Related to : https://github.com/riscv-software-src/riscv-pk/pull/308

The current config.sub script does not allow building the pk with "riscv-none-*" as host name.
This fixes the issue without changing most of the current config.sub script and does not change config.guess.