### PR TITLE
Enable shadow stack from .note.gnu.property

### DIFF
--- a/pk/boot.h
+++ b/pk/boot.h
@@ -6,6 +6,7 @@
 #ifndef __ASSEMBLER__
 
 #include <stddef.h>
+#include <stdbool.h>
 
 typedef struct {
   int phent;
@@ -24,6 +25,8 @@ typedef struct {
   uint64_t time0;
   uint64_t cycle0;
   uint64_t instret0;
+  bool shstk;
+  bool lpad;
 } elf_info;
 
 extern elf_info current;

--- a/pk/elf.h
+++ b/pk/elf.h
@@ -15,9 +15,11 @@
 #if __riscv_xlen == 64
 # define Elf_Ehdr Elf64_Ehdr
 # define Elf_Phdr Elf64_Phdr
+# define Elf_Note Elf64_Note
 #else
 # define Elf_Ehdr Elf32_Ehdr
 # define Elf_Phdr Elf32_Phdr
+# define Elf_Note Elf32_Note
 #endif
 
 #define ET_EXEC 2
@@ -27,6 +29,17 @@
 
 #define PT_LOAD 1
 #define PT_INTERP 3
+#define PT_LOOS 0x60000000
+#define PT_GNU_PROPERTY (PT_LOOS + 0x474e553)
+#define GNU_PROPERTY_TYPE_0_NAME "GNU"
+#define NOTE_NAME_SZ (sizeof(GNU_PROPERTY_TYPE_0_NAME))
+
+#define NT_GNU_PROPERTY_TYPE_0 5
+#define GNU_PROPERTY_ALIGN 4
+
+#define GUN_PROPERTY_RISCV_FEATURE_1_AND 0xc0000000
+#define GNU_PROPERTY_RISCV_FEATURE_1_ZICFILP (1 << 0)
+#define GNU_PROPERTY_RISCV_FEATURE_1_ZICFISS (1 << 1)
 
 #define AT_NULL   0
 #define AT_PHDR   3
@@ -142,5 +155,22 @@ typedef struct {
   uint64_t st_value;
   uint64_t st_size;
 } Elf64_Sym;
+
+typedef struct {
+  uint32_t n_namesz;
+  uint32_t n_descsz;
+  uint32_t n_type;
+} Elf32_Note;
+
+typedef struct {
+  uint32_t n_namesz;
+  uint32_t n_descsz;
+  uint32_t n_type;
+} Elf64_Note;
+
+struct gnu_property {
+  uint32_t pr_type;
+  uint32_t pr_datasz;
+};
 
 #endif

--- a/pk/mmap.c
+++ b/pk/mmap.c
@@ -327,6 +327,11 @@ static int __handle_page_fault(uintptr_t vaddr, int prot)
   }
 
   pte_t perms = pte_create(0, prot_to_type(prot, 1));
+
+  // allow shadow stack only allocate W permission
+  // maybe we should check insn which is shstk insn from epc
+  if (current.shstk)
+    return 0;
   if ((*pte & perms) != perms)
     return -1;
 


### PR DESCRIPTION
reference from llvm-project commit https://github.com/llvm/llvm-project/pull/77414

1. Parse .note.gun.property to check Zicfiss/Zicfilp properties
2. If Zicfiss on, we should allocate SS(Shadow stack) page with PROT_WRITE
3. We should allow allocate no-read page when SS page allocating

Some tasks require discussion:

- What should the default shadow stack size be?
- How to allow page allocation only for write-only pages?
> - Checking instruction with epc address? (Maybe this is more in line with hardware behavior.)
> - Checking ELF enable shstk flag?