### PR TITLE
Remove "bbl loader" message

### DIFF
--- a/machine/minit.c
+++ b/machine/minit.c
@@ -191,7 +191,6 @@ void init_first_hart(uintptr_t hartid, uintptr_t dtb)
   query_uart16550(dtb);
   query_uart_litex(dtb);
   query_htif(dtb);
-  printm("bbl loader\r\n");
 
   hart_init();
   hls_init(0); // this might get called again from parse_config_string


### PR DESCRIPTION
It was originally added as a temporary hack to hide a race condition in a prototype.  It should've been removed long ago.

Resolves #312