### PR TITLE
Implementation of riscv_hwprobe syscall from Linux

### DIFF
--- a/machine/minit.c
+++ b/machine/minit.c
@@ -17,6 +17,7 @@
 uintptr_t mem_size;
 volatile uint64_t* mtime;
 volatile uint32_t* plic_priorities;
+uint64_t misa_image;
 size_t plic_ndevs;
 void* kernel_start;
 void* kernel_end;
@@ -125,6 +126,7 @@ static void memory_init()
 
 static void hart_init()
 {
+  misa_image = read_csr(misa);
   mstatus_init();
   fp_init();
 #ifndef BBL_BOOT_MACHINE

--- a/machine/mtrap.h
+++ b/machine/mtrap.h
@@ -35,6 +35,7 @@ extern uintptr_t mem_size;
 extern volatile uint64_t* mtime;
 extern volatile uint32_t* plic_priorities;
 extern size_t plic_ndevs;
+extern uint64_t misa_image;
 
 typedef struct {
   volatile uint32_t* ipi;

--- a/pk/syscall.h
+++ b/pk/syscall.h
@@ -59,6 +59,7 @@
 #define SYS_madvise 233
 #define SYS_statx 291
 #define SYS_readv 65
+#define SYS_riscv_hwprobe 258
 
 #define OLD_SYSCALL_THRESHOLD 1024
 #define SYS_open 1024


### PR DESCRIPTION
See: https://www.kernel.org/doc/html/latest/arch/riscv/hwprobe.html

Please note that there is just a partial support, as I aimed to dynamic detection of the V extension. TBH I'm not 100% happy with solution, as I feel like we should use `mstatus` rather than `misa`. Appreciate any feedback.