### PR TITLE
pk: use kassert in load_elf instead of assert

### DIFF
--- a/pk/elf.c
+++ b/pk/elf.c
@@ -38,13 +38,13 @@ void load_elf(const char* fn, elf_info* info)
     goto fail;
 
 #if __riscv_xlen == 64
-  assert(IS_ELF64(eh));
+  kassert(IS_ELF64(eh));
 #else
-  assert(IS_ELF32(eh));
+  kassert(IS_ELF32(eh));
 #endif
 
 #ifndef __riscv_compressed
-  assert(!(eh.e_flags & EF_RISCV_RVC));
+  kassert(!(eh.e_flags & EF_RISCV_RVC));
 #endif
 
   size_t phdr_size = eh.e_phnum * sizeof(Elf_Phdr);


### PR DESCRIPTION
This avoids calling into assert and eventually `printm` (which might use UART using physical addresses, etc) in supervisor mode.

Without this patch, reproducing #297 can cause the following memory fault.
```
z  0000000000000000 ra ffffffc000006a20 sp ffffffc000427d10 gp 0000000000000000
tp 0000000000000000 t0 0000000080000004 t1 0000000080000004 t2 0000000000000000
s0 ffffffc000427d30 s1 0000000000000000 a0 000000000000002e a1 0000000000000100
a2 ffffffc000015da8 a3 0000000000000005 a4 0000000000000005 a5 0000000010000005
a6 0000000000000000 a7 0000000000000000 s2 0000000000000000 s3 0000000000000000
s4 0000000000000000 s5 0000000000000000 s6 0000000000000000 s7 0000000000000000
s8 0000000000000000 s9 0000000000000000 sA 0000000000000000 sB 0000000000000000
t3 0000000000000000 t4 0000000000000000 t5 0000000000000000 t6 0000000000000000
pc ffffffc0000086f4 va/inst 0000000010000005 sr 8000000200006100
Kernel load segfault @ 0x0000000010000005
```