### PR TITLE
Add no-op futex syscall implementation

### DIFF
--- a/pk/syscall.c
+++ b/pk/syscall.c
@@ -518,7 +518,7 @@ int sys_times(long* loc)
   kloc[0] = t / (CLOCK_FREQ / 1000000);
 
   memcpy_to_user(loc, kloc, sizeof(kloc));
-  
+
   return 0;
 }
 
@@ -531,7 +531,7 @@ int sys_gettimeofday(long* loc)
   kloc[1] = (t % CLOCK_FREQ) / (CLOCK_FREQ / 1000000);
 
   memcpy_to_user(loc, kloc, sizeof(kloc));
-  
+
   return 0;
 }
 
@@ -770,6 +770,7 @@ long do_syscall(long a0, long a1, long a2, long a3, long a4, long a5, unsigned l
     [SYS_readlinkat] = sys_readlinkat,
     [SYS_readv] = sys_readv,
     [SYS_riscv_hwprobe] = sys_riscv_hwprobe,
+    [SYS_futex] = sys_stub_success,
   };
 
   const static void* old_syscall_table[] = {

--- a/pk/syscall.h
+++ b/pk/syscall.h
@@ -60,6 +60,7 @@
 #define SYS_statx 291
 #define SYS_readv 65
 #define SYS_riscv_hwprobe 258
+#define SYS_futex 98
 
 #define OLD_SYSCALL_THRESHOLD 1024
 #define SYS_open 1024


### PR DESCRIPTION
This allows simple programs compiled with modern versions of GLIBC to work with `pk`. For example:

`hello.cc`:
```
#include <iostream>
int main(void) {
  std::cout << "Hello!" << std::endl;
  return 0;
}
```

Compile/test:
```
riscv64-unknown-linux-gnu-gcc hello.cc -lstdc++ -static -o hello
spike pk hello
```

Solution was previously given in:
https://github.com/riscv-software-src/riscv-pk/issues/207
https://github.com/riscv-software-src/riscv-isa-sim/issues/1443
https://github.com/riscv-software-src/riscv-isa-sim/issues/1605