### PR TITLE
Fixes #330 Set mstatus before querying uart

### DIFF
--- a/machine/minit.c
+++ b/machine/minit.c
@@ -191,6 +191,7 @@ static void wake_harts()
 
 void init_first_hart(uintptr_t hartid, uintptr_t dtb)
 {
+  mstatus_init();
   // Confirm console as early as possible
   query_uart(dtb);
   query_uart16550(dtb);


### PR DESCRIPTION
Fixes #330 by setting mstatus value before querying UART