### PR TITLE
Fix #345 : Add dtb into .data section in pk linker

### DIFF
--- a/pk/pk.lds
+++ b/pk/pk.lds
@@ -67,6 +67,7 @@ SECTIONS
     *(.srodata*)
     *(.gnu.linkonce.d.*)
     *(.comment)
+    *(.dtb)
   }
 
   /* End of initialized data segment */


### PR DESCRIPTION
Fix issue #345, Embed custom device tree in pk to enable bare-metal execution on custom SoC